### PR TITLE
Expand base bounds so as to build with GHC 9.2.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           - "8.8.4"
           - "8.10.4"
           - "9.0.1"
+          - "9.2.1"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,5 @@
+* Bumped upper bounds for GHC 9.2 and older.
+
 ## 0.3.0.1
 
 * Bumped upper bounds for GHC 8.8.

--- a/named.cabal
+++ b/named.cabal
@@ -37,7 +37,7 @@ bug-reports:         https://github.com/monadfix/named/issues
 category:            Control
 build-type:          Simple
 extra-source-files:  ChangeLog.md
-tested-with:         GHC ==8.0.2, GHC ==8.2.2, GHC ==8.4.4, GHC ==8.6.5, GHC ==8.8.1
+tested-with:         GHC ==8.0.2, GHC ==8.2.2, GHC ==8.4.4, GHC ==8.6.5, GHC ==8.8.1, GHC ==9.2.1
 cabal-version:       >=1.10
 
 source-repository head
@@ -46,7 +46,7 @@ source-repository head
 
 library
   exposed-modules:     Named, Named.Internal
-  build-depends:       base >=4.9 && <4.16
+  build-depends:       base >=4.9 && <4.17
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/named.cabal
+++ b/named.cabal
@@ -56,7 +56,7 @@ test-suite regression
   type:                exitcode-stdio-1.0
   main-is:             Test.hs
   other-modules:       TestImport
-  build-depends:       base >=4.9 && <4.16,
+  build-depends:       base >=4.9 && <4.17,
                        named
   hs-source-dirs:      test
   default-language:    Haskell2010


### PR DESCRIPTION
Fixes #33.