### PR TITLE
Varargs version to avoid needing !

### DIFF
--- a/named.cabal
+++ b/named.cabal
@@ -45,7 +45,7 @@ source-repository head
   location: git@github.com:monadfix/named.git
 
 library
-  exposed-modules:     Named, Named.Internal
+  exposed-modules:     Named, Named.Internal, Named.Varargs
   build-depends:       base >=4.9 && <4.17
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Named/Varargs.hs
+++ b/src/Named/Varargs.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE OverlappingInstances #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE PatternSynonyms #-}
+
+{- | Exports 'withs' which allows the call site to avoid using '!'.
+
+Example ghci session:
+
+> :set -XAllowAmbiguousTypes -XFlexibleContexts -XDataKinds -XOverloadedLabels -XRebindableSyntax
+> import Named
+> import Named.Varargs
+> import Prelude -- needed by -XRebindableSyntax
+> let f (arg #x -> x) (argDef #y [1,2,3] -> y) = x:y
+> :t withs f #x 3 End
+withs f #x 3 End :: Num x => [x]
+> withs f #x 3 End
+[3,1,2,3]
+
+> withs f #x 3 #y [5] End
+[3,5]
+> withs f #y [] #x 3 End
+[3]
+
+> let g x = withs f x
+> g #x 3 End
+[3,1,2,3]
+
+> g End ! param #x 4
+[4,1,2,3]
+
+
+-}
+module Named.Varargs (WithParams(withs), pattern End, fromLabel) where
+
+import Named
+import Named.Internal
+import Data.Functor.Identity (Identity)
+
+fromLabel :: Name name
+fromLabel = Name
+
+class WithParams a where
+  withs :: a
+
+instance (WithParam p a b,
+        p ~ NamedF f x name,
+        Applicative f,
+        v ~ (Name name -> x -> c),
+        WithParams (b -> c)) =>
+        WithParams (a -> v) where
+  withs f n v = withs (with (paramF n (pure v) :: Param p) f)
+
+pattern End = Param Defaults
+
+instance (WithParam Defaults a b)
+        => WithParams (a -> Param Defaults -> b) where
+  withs x End = x ! defaults


### PR DESCRIPTION
Maybe this should be exported from Named instead? Or Named.Varargs should reexport the needed parts of Named?

I would also like the equivalent of these two functions: [R's ... extra arguments](https://stat.ethz.ch/R-manual/R-devel/library/base/html/dots.html) and [R's do.call](https://stat.ethz.ch/R-manual/R-devel/library/base/html/do.call.html). Maybe we don't need an intermediate hlist of extra arguments. If the function wants a `va_list`, perhaps `withs` could accept extra arguments and supply a function that applies them. In other words, I'm proposing that the following would print '3'
```haskell
main = print $ withs f #x 2 End
f (arg #va_list -> g) = g h
h (arg #x -> x) = x+1
```